### PR TITLE
Improve request events instrumentation

### DIFF
--- a/lib/stripe/instrumentation.rb
+++ b/lib/stripe/instrumentation.rb
@@ -33,6 +33,7 @@ module Stripe
       attr_reader :num_retries
       attr_reader :path
       attr_reader :request_id
+      attr_reader :response
 
       # Arbitrary user-provided data in the form of a Ruby hash that's passed
       # from subscribers on `request_begin` to subscribers on `request_end`.
@@ -41,7 +42,7 @@ module Stripe
       attr_reader :user_data
 
       def initialize(duration:, http_status:, method:, num_retries:, path:,
-                     request_id:, user_data: nil)
+                     request_id:, user_data: nil, response: nil)
         @duration = duration
         @http_status = http_status
         @method = method
@@ -49,6 +50,7 @@ module Stripe
         @path = path
         @request_id = request_id
         @user_data = user_data
+        @response = response
         freeze
       end
     end

--- a/lib/stripe/instrumentation.rb
+++ b/lib/stripe/instrumentation.rb
@@ -34,6 +34,7 @@ module Stripe
       attr_reader :path
       attr_reader :request_id
       attr_reader :response
+      attr_reader :request_body
 
       # Arbitrary user-provided data in the form of a Ruby hash that's passed
       # from subscribers on `request_begin` to subscribers on `request_end`.
@@ -42,7 +43,7 @@ module Stripe
       attr_reader :user_data
 
       def initialize(duration:, http_status:, method:, num_retries:, path:,
-                     request_id:, user_data: nil, response: nil)
+                     request_id:, user_data: nil, response: nil, request_body: nil)
         @duration = duration
         @http_status = http_status
         @method = method
@@ -51,6 +52,7 @@ module Stripe
         @request_id = request_id
         @user_data = user_data
         @response = response
+        @request_body = request_body
         freeze
       end
     end

--- a/lib/stripe/instrumentation.rb
+++ b/lib/stripe/instrumentation.rb
@@ -33,7 +33,8 @@ module Stripe
       attr_reader :num_retries
       attr_reader :path
       attr_reader :request_id
-      attr_reader :response
+      attr_reader :response_header
+      attr_reader :response_body
       attr_reader :request_header
       attr_reader :request_body
 
@@ -43,15 +44,17 @@ module Stripe
       # in `request_end`.
       attr_reader :user_data
 
-      def initialize(request_context:,
+      def initialize(request_context:, response_context:,
                      num_retries:, user_data: nil)
         @duration = request_context.duration
-        @http_status = http_status
+        @http_status = response_context.http_status
         @method = request_context.method
         @num_retries = num_retries
         @path = request_context.path
         @request_id = request_context.request_id
         @user_data = user_data
+        @response_header = response_context.header
+        @response_body = response_context.body
         @request_header = request_context.header
         @request_body = request_context.body
         freeze
@@ -75,6 +78,19 @@ module Stripe
         @header = header
       end
     end
+
+    class ResponseContext
+      attr_reader :http_status
+      attr_reader :body
+      attr_reader :header
+
+      def initialize(http_status:, response:)
+        @http_status = http_status
+        @header = response.to_hash
+        @body = response.body
+      end
+    end
+
     # This class was renamed for consistency. This alias is here for backwards
     # compatibility.
     RequestEvent = RequestEndEvent

--- a/lib/stripe/instrumentation.rb
+++ b/lib/stripe/instrumentation.rb
@@ -86,8 +86,8 @@ module Stripe
 
       def initialize(http_status:, response:)
         @http_status = http_status
-        @header = response.to_hash
-        @body = response.body
+        @header = response ? response.to_hash : nil
+        @body = response ? response.body : nil
       end
     end
 

--- a/lib/stripe/instrumentation.rb
+++ b/lib/stripe/instrumentation.rb
@@ -34,6 +34,7 @@ module Stripe
       attr_reader :path
       attr_reader :request_id
       attr_reader :response
+      attr_reader :request_header
       attr_reader :request_body
 
       # Arbitrary user-provided data in the form of a Ruby hash that's passed
@@ -43,7 +44,7 @@ module Stripe
       attr_reader :user_data
 
       def initialize(duration:, http_status:, method:, num_retries:, path:,
-                     request_id:, user_data: nil, response: nil, request_body: nil)
+                     request_id:, user_data: nil, response: nil, request_header: nil, request_body: nil)
         @duration = duration
         @http_status = http_status
         @method = method
@@ -52,6 +53,7 @@ module Stripe
         @request_id = request_id
         @user_data = user_data
         @response = response
+        @request_header = request_header
         @request_body = request_body
         freeze
       end

--- a/lib/stripe/instrumentation.rb
+++ b/lib/stripe/instrumentation.rb
@@ -43,22 +43,38 @@ module Stripe
       # in `request_end`.
       attr_reader :user_data
 
-      def initialize(duration:, http_status:, method:, num_retries:, path:,
-                     request_id:, user_data: nil, response: nil, request_header: nil, request_body: nil)
-        @duration = duration
+      def initialize(request_context:,
+                     num_retries:, user_data: nil)
+        @duration = request_context.duration
         @http_status = http_status
-        @method = method
+        @method = request_context.method
         @num_retries = num_retries
-        @path = path
-        @request_id = request_id
+        @path = request_context.path
+        @request_id = request_context.request_id
         @user_data = user_data
-        @response = response
-        @request_header = request_header
-        @request_body = request_body
+        @request_header = request_context.header
+        @request_body = request_context.body
         freeze
       end
     end
 
+    class RequestContext
+      attr_reader :duration
+      attr_reader :method
+      attr_reader :path
+      attr_reader :request_id
+      attr_reader :body
+      attr_reader :header
+
+      def initialize(duration:, context:, header:)
+        @duration = duration
+        @method = context.method
+        @path = context.path
+        @request_id = context.request_id
+        @body = context.body
+        @header = header
+      end
+    end
     # This class was renamed for consistency. This alias is here for backwards
     # compatibility.
     RequestEvent = RequestEndEvent

--- a/lib/stripe/stripe_client.rb
+++ b/lib/stripe/stripe_client.rb
@@ -669,7 +669,8 @@ module Stripe
         path: context.path,
         request_id: context.request_id,
         user_data: user_data || {},
-        response: resp
+        response: resp,
+        request_body: context.body
       )
       Stripe::Instrumentation.notify(:request_end, event)
 

--- a/lib/stripe/stripe_client.rb
+++ b/lib/stripe/stripe_client.rb
@@ -662,17 +662,17 @@ module Stripe
       return if !Instrumentation.any_subscribers?(:request_end) &&
                 !Instrumentation.any_subscribers?(:request)
 
-      event = Instrumentation::RequestEndEvent.new(
+      request_context = Stripe::Instrumentation::RequestContext.new(
         duration: duration,
+        context: context,
+        header: headers
+      )
+
+      event = Instrumentation::RequestEndEvent.new(
         http_status: http_status,
-        method: context.method,
+        request_context: request_context,
         num_retries: num_retries,
-        path: context.path,
-        request_id: context.request_id,
         user_data: user_data || {},
-        response: resp,
-        request_header: headers,
-        request_body: context.body
       )
       Stripe::Instrumentation.notify(:request_end, event)
 

--- a/lib/stripe/stripe_client.rb
+++ b/lib/stripe/stripe_client.rb
@@ -587,7 +587,7 @@ module Stripe
 
         log_response(context, request_start, http_status, resp.body, resp)
         notify_request_end(context, request_duration, http_status,
-                           num_retries, user_data)
+                           num_retries, user_data, resp)
 
         if config.enable_telemetry? && context.request_id
           request_duration_ms = (request_duration * 1000).to_i
@@ -614,7 +614,7 @@ module Stripe
           log_response_error(error_context, request_start, e)
         end
         notify_request_end(context, request_duration, http_status, num_retries,
-                           user_data)
+                           user_data, resp)
 
         if self.class.should_retry?(e,
                                     method: method,
@@ -657,7 +657,7 @@ module Stripe
     end
 
     private def notify_request_end(context, duration, http_status, num_retries,
-                                   user_data)
+                                   user_data, resp)
       return if !Instrumentation.any_subscribers?(:request_end) &&
                 !Instrumentation.any_subscribers?(:request)
 
@@ -668,7 +668,8 @@ module Stripe
         num_retries: num_retries,
         path: context.path,
         request_id: context.request_id,
-        user_data: user_data || {}
+        user_data: user_data || {},
+        response: resp
       )
       Stripe::Instrumentation.notify(:request_end, event)
 

--- a/lib/stripe/stripe_client.rb
+++ b/lib/stripe/stripe_client.rb
@@ -667,12 +667,16 @@ module Stripe
         context: context,
         header: headers
       )
+      response_context = Stripe::Instrumentation::ResponseContext.new(
+        http_status: http_status,
+        response: resp
+      )
 
       event = Instrumentation::RequestEndEvent.new(
-        http_status: http_status,
         request_context: request_context,
+        response_context: response_context,
         num_retries: num_retries,
-        user_data: user_data || {},
+        user_data: user_data || {}
       )
       Stripe::Instrumentation.notify(:request_end, event)
 

--- a/lib/stripe/stripe_client.rb
+++ b/lib/stripe/stripe_client.rb
@@ -494,15 +494,16 @@ module Stripe
           end
         end
 
-      http_resp = execute_request_with_rescues(method, api_base, context) do
-        self.class
-            .default_connection_manager(config)
-            .execute_request(method, url,
-                             body: body,
-                             headers: headers,
-                             query: query,
-                             &response_block)
-      end
+      http_resp =
+        execute_request_with_rescues(method, api_base, headers, context) do
+          self.class
+              .default_connection_manager(config)
+              .execute_request(method, url,
+                               body: body,
+                               headers: headers,
+                               query: query,
+                               &response_block)
+        end
 
       [http_resp, api_key]
     end
@@ -564,7 +565,7 @@ module Stripe
       http_status >= 400
     end
 
-    private def execute_request_with_rescues(method, api_base, context)
+    private def execute_request_with_rescues(method, api_base, headers, context)
       num_retries = 0
 
       begin
@@ -587,7 +588,7 @@ module Stripe
 
         log_response(context, request_start, http_status, resp.body, resp)
         notify_request_end(context, request_duration, http_status,
-                           num_retries, user_data, resp)
+                           num_retries, user_data, resp, headers)
 
         if config.enable_telemetry? && context.request_id
           request_duration_ms = (request_duration * 1000).to_i
@@ -614,7 +615,7 @@ module Stripe
           log_response_error(error_context, request_start, e)
         end
         notify_request_end(context, request_duration, http_status, num_retries,
-                           user_data, resp)
+                           user_data, resp, headers)
 
         if self.class.should_retry?(e,
                                     method: method,
@@ -657,7 +658,7 @@ module Stripe
     end
 
     private def notify_request_end(context, duration, http_status, num_retries,
-                                   user_data, resp)
+                                   user_data, resp, headers)
       return if !Instrumentation.any_subscribers?(:request_end) &&
                 !Instrumentation.any_subscribers?(:request)
 
@@ -670,6 +671,7 @@ module Stripe
         request_id: context.request_id,
         user_data: user_data || {},
         response: resp,
+        request_header: headers,
         request_body: context.body
       )
       Stripe::Instrumentation.notify(:request_end, event)

--- a/test/stripe/instrumentation_test.rb
+++ b/test/stripe/instrumentation_test.rb
@@ -58,13 +58,29 @@ module Stripe
 
     context "RequestEventEnd" do
       should "return a frozen object" do
-        event = Stripe::Instrumentation::RequestEndEvent.new(
+        mock_context = stub(
           duration: 0.1,
-          http_status: 200,
           method: :get,
-          num_retries: 0,
           path: "/v1/test",
           request_id: "req_123",
+          body: ""
+        )
+
+        request_context = Stripe::Instrumentation::RequestContext.new(
+          duration: 0.1,
+          context: mock_context,
+          header: nil
+        )
+
+        response_context = Stripe::Instrumentation::ResponseContext.new(
+          http_status: 200,
+          response: nil
+        )
+
+        event = Stripe::Instrumentation::RequestEndEvent.new(
+          num_retries: 0,
+          request_context: request_context,
+          response_context: response_context,
           user_data: nil
         )
 


### PR DESCRIPTION
### What are you trying to accomplish?
This is an extension of the simple instrumentation callback what has been done previously in https://github.com/stripe/stripe-ruby/pull/870.

To create our own event logs of Stripe calls, we were missing certain informations when we subscribe to `Request`. The missing informations that we would like to have access to are:
- Request both headers and body
- Response headers and body

### What approach did you choose and why?
We simply added the missing fields to the `RequestEndEvent` class.

Please correct me if I am wrong, but here is my understanding on where to retrieve the missing informations.
- Context seems to hold the information about the request
  - `context.body` would hold the request body information
- Resp seems to be the response
  - `resp.body` holds the response body
  - `resp.to_hash` seems to hold the hidden response headers

### What should reviewers focus on?
I couldn't find a proper way to retrieve the whole request headers. It seems like `context` does have certain header fields exposed but it's a "shorten version".

Can anyone help me add a test for the `request_body`? 👀 

🎩 : https://abacus.stripe-logs-abacus.leena-nguyen.us.spin.dev/shop/2/activity_logs?selectedRequestId=req_vjzQzsBlvdIRec